### PR TITLE
Add simple frontend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Execute the backend unit tests using Python's `unittest`:
 python -m unittest discover -s tests
 ```
 
+For simple frontend checks using Node's built-in test runner:
+```bash
+cd frontend
+npm test
+```
+
 ## Repository Layout
 - `backend/` &ndash; Flask application and Dockerfile
 - `frontend/` &ndash; React/Vite frontend and Dockerfile

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^16.3.0",

--- a/frontend/tests/basic.test.js
+++ b/frontend/tests/basic.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+// Helper to resolve paths relative to this file
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function resolve(relPath) {
+  return path.join(__dirname, '..', relPath);
+}
+
+test('index.html has root div and script tag', () => {
+  const html = readFileSync(resolve('index.html'), 'utf8');
+  assert.match(html, /<div id="root"><\/div>/);
+  assert.match(html, /<script type="module" src="\/src\/main.jsx"><\/script>/);
+});
+
+test('package.json defines expected npm scripts', () => {
+  const pkg = JSON.parse(readFileSync(resolve('package.json'), 'utf8'));
+  assert.ok(pkg.scripts && pkg.scripts.dev, 'dev script missing');
+  assert.ok(pkg.scripts && pkg.scripts.build, 'build script missing');
+  assert.ok(pkg.scripts && pkg.scripts.preview, 'preview script missing');
+});


### PR DESCRIPTION
## Summary
- add basic frontend tests using Node's test runner
- expose `npm test` script
- document frontend tests in README

## Testing
- `python -m unittest discover -s tests`
- `cd frontend && npm test`
