### PR TITLE
Add tests for backend task validation and frontend config

### DIFF
--- a/frontend/tests/basic.test.js
+++ b/frontend/tests/basic.test.js
@@ -24,3 +24,15 @@ test('package.json defines expected npm scripts', () => {
   assert.ok(pkg.scripts && pkg.scripts.build, 'build script missing');
   assert.ok(pkg.scripts && pkg.scripts.preview, 'preview script missing');
 });
+
+import tailwindConfig from '../tailwind.config.js';
+
+test('tailwind config includes index.html', () => {
+  assert.ok(tailwindConfig.content.includes('./index.html'));
+});
+
+test('main.jsx renders App inside StrictMode', () => {
+  const src = readFileSync(resolve('src/main.jsx'), 'utf8');
+  assert.match(src, /<StrictMode>/);
+  assert.match(src, /<App \/>/);
+});


### PR DESCRIPTION
## Summary
- extend backend API tests for task creation edge cases and undo
- add frontend tests for Tailwind config and main entry

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test --silent`