### PR TITLE
Remove duplicate requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains a small Flask backend and a React frontend built with V
    ```bash
    python -m venv venv && source venv/bin/activate
    ```
-3. Install dependencies
+3. Install dependencies (the `requirements.txt` file lives in `backend/`)
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-Flask==2.0.1
-Flask-CORS==3.0.10
-pytz==2023.3
-gunicorn==20.1.0
-# Add werkzeug version to ensure compatibility
-Werkzeug==2.0.1


### PR DESCRIPTION
## Summary
- remove the root requirements.txt so only backend/requirements.txt is used
- clarify in README that the requirements file lives in the backend folder

## Testing
- `PYTHONPATH=. pytest -q`
- `cd frontend && npm test`