### PR TITLE
Add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ cython_debug/
 
 # Node
 node_modules/
+package-lock.json
 
 # Vite
 /dist/


### PR DESCRIPTION
## Summary
- ignore `package-lock.json` files

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test` from `frontend`