### PR TITLE
Fix JSX fragment mismatch in TaskManager

### DIFF
--- a/frontend/src/components/TaskManager.jsx
+++ b/frontend/src/components/TaskManager.jsx
@@ -654,9 +654,8 @@ return (
                       </div>
 
                         {!collapsedAreas.has(area.key) && (
-                          <>
-                            {/* Objectives section */}
-                            <Droppable droppableId={area.key} type="objective">
+                          // Objectives section
+                          <Droppable droppableId={area.key} type="objective">
                               {(provided) => (
                                 <div
                                   {...provided.droppableProps}
@@ -726,10 +725,9 @@ return (
                                 onClick={() => handleAddObjective(area.key)}
                               />
                             </div>
-                          </div>
-                        )}
-                      </Droppable>
-                      </>
+                            </div>
+                          )}
+                        </Droppable>
                     </div>
                   )}
                 </Draggable>

--- a/frontend/tests/jsx.test.js
+++ b/frontend/tests/jsx.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+function resolve(relPath) {
+  return path.join(__dirname, '..', relPath);
+}
+
+test('TaskManager JSX fragments are balanced', () => {
+  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const opens = (src.match(/<>/g) || []).length;
+  const closes = (src.match(/<\/>/g) || []).length;
+  assert.equal(opens, closes);
+});


### PR DESCRIPTION
## Summary
- fix unmatched JSX fragment in `TaskManager.jsx`
- add regression test to check fragment balance

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test --silent`