### PR TITLE
Persist auth state in frontend

### DIFF
--- a/frontend/src/components/TaskManager.jsx
+++ b/frontend/src/components/TaskManager.jsx
@@ -5,6 +5,7 @@ import TaskItem from './TaskItem';
 import { v4 as uuidv4 } from 'uuid';
 import apiWrapper from '../api';
 import ReactMarkdown from 'react-markdown';
+import { getStoredAuth, storeAuth, clearAuth } from '../utils/auth';
 const TaskManager = () => {
     const [authenticated, setAuthenticated] = useState(false);
     const [passcode, setPasscode] = useState('');
@@ -19,6 +20,12 @@ const TaskManager = () => {
     const [error, setError] = useState(null);
     const editInputRef = useRef(null);
     const editInputBottomRef = useRef(null);
+
+    useEffect(() => {
+      if (getStoredAuth()) {
+        setAuthenticated(true);
+      }
+    }, []);
   
     useEffect(() => {
       if (authenticated) {
@@ -99,10 +106,16 @@ const TaskManager = () => {
       if (event.key === 'Enter') {
         if (passcode === 'sneeze') {
           setAuthenticated(true);
+          storeAuth();
         } else {
           setPasscode('');
         }
       }
+    };
+
+    const handleLogout = () => {
+      clearAuth();
+      setAuthenticated(false);
     };
 // Area handlers
 const handleAreaClick = (area, event, isBottom = false) => {

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,0 +1,15 @@
+export function getStoredAuth() {
+  return typeof localStorage !== 'undefined' && localStorage.getItem('authenticated') === 'true';
+}
+
+export function storeAuth() {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('authenticated', 'true');
+  }
+}
+
+export function clearAuth() {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.removeItem('authenticated');
+  }
+}

--- a/frontend/tests/authPersistence.test.js
+++ b/frontend/tests/authPersistence.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getStoredAuth, storeAuth, clearAuth } from '../src/utils/auth.js';
+
+class MockStorage {
+  constructor() { this.store = {}; }
+  getItem(k) { return Object.prototype.hasOwnProperty.call(this.store, k) ? this.store[k] : null; }
+  setItem(k, v) { this.store[k] = String(v); }
+  removeItem(k) { delete this.store[k]; }
+}
+
+test('authentication state persists via localStorage', () => {
+  const mock = new MockStorage();
+  global.localStorage = mock;
+  assert.equal(getStoredAuth(), false);
+  storeAuth();
+  assert.equal(mock.getItem('authenticated'), 'true');
+  // simulate reload by calling getStoredAuth again
+  assert.equal(getStoredAuth(), true);
+  clearAuth();
+  assert.equal(mock.getItem('authenticated'), null);
+});


### PR DESCRIPTION
## Summary
- load authentication state from localStorage on mount
- persist auth status when passcode is entered
- expose simple auth helpers in `src/utils/auth.js`
- add test verifying localStorage persistence

## Testing
- `npm test --prefix frontend`
- `PYTHONPATH=. pytest -q`