### PR TITLE
Fix JSX closing tags in TaskManager

### DIFF
--- a/frontend/src/components/TaskManager.jsx
+++ b/frontend/src/components/TaskManager.jsx
@@ -728,6 +728,7 @@ return (
                             </div>
                           )}
                         </Droppable>
+                      )}
                     </div>
                   )}
                 </Draggable>


### PR DESCRIPTION
## Summary
- correct closing of conditional JSX block in `TaskManager.jsx`

## Testing
- `npm test --prefix frontend`
- `PYTHONPATH=. pytest -q`
