### PR TITLE
Refactor TaskManager rendering helpers

### DIFF
--- a/frontend/src/components/TaskManager.jsx
+++ b/frontend/src/components/TaskManager.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { Cross2Icon, PlusIcon, CheckIcon, ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons';
 import TaskItem from './TaskItem';
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import apiWrapper from '../api';
 import ReactMarkdown from 'react-markdown';
 import { getStoredAuth, storeAuth, clearAuth } from '../utils/auth';
+import { divSpec, specToReact } from '../utils/divBuilder';
 const TaskManager = () => {
     const [authenticated, setAuthenticated] = useState(false);
     const [passcode, setPasscode] = useState('');
@@ -566,18 +567,24 @@ const handleTaskChange = (e) => {
   };
 
   if (!authenticated) {
-    return (
-      <div className="h-screen w-screen flex items-center justify-center font-mate bg-[#f5f5dc]">
-        <input
-          type="password"
-          value={passcode}
-          onChange={(e) => setPasscode(e.target.value)}
-          onKeyPress={handleKeyPress}
-          className="border p-2 text-center w-48 outline-none text-sm bg-transparent"
-          autoFocus
-        />
-      </div>
-    );
+    const spec = divSpec({
+      className: 'h-screen w-screen flex items-center justify-center font-mate bg-[#f5f5dc]',
+      children: [
+        divSpec({
+          children: (
+            <input
+              type="password"
+              value={passcode}
+              onChange={(e) => setPasscode(e.target.value)}
+              onKeyPress={handleKeyPress}
+              className="border p-2 text-center w-48 outline-none text-sm bg-transparent"
+              autoFocus
+            />
+          )
+        })
+      ]
+    });
+    return specToReact(spec, React);
   }
 
 // This goes in your TaskManager component, replacing the current return statement

--- a/frontend/src/utils/divBuilder.js
+++ b/frontend/src/utils/divBuilder.js
@@ -1,0 +1,38 @@
+/**
+ * Build a specification object representing a <div> with optional className and children.
+ * Children may be strings or other spec objects.
+ */
+export function divSpec({ className = '', children = [] } = {}) {
+  return { className, children };
+}
+
+/** Convert a spec object into an HTML string. */
+export function specToHtml(spec) {
+  if (!spec) return '';
+  const { className, children } = spec;
+  const attr = className ? ` class="${className}"` : '';
+  const inner = Array.isArray(children)
+    ? children.map(specToHtml).join('')
+    : (children || '');
+  return `<div${attr}>${inner}</div>`;
+}
+
+/** Convert a spec into React elements using the provided React implementation. */
+export function specToReact(spec, ReactLib) {
+  if (!spec) return null;
+  const { createElement, isValidElement } = ReactLib;
+  const { className, children } = spec;
+  const mapped = Array.isArray(children)
+    ? children.map(child => (typeof child === 'object' && child && !isValidElement(child)
+        ? specToReact(child, ReactLib)
+        : child))
+    : children;
+  return createElement('div', { className }, mapped);
+}
+
+/** Validate that opening and closing <div> tags match. */
+export function isValidDivString(html) {
+  const open = (html.match(/<div/g) || []).length;
+  const close = (html.match(/<\/div>/g) || []).length;
+  return open === close;
+}

--- a/frontend/tests/divBuilder.test.js
+++ b/frontend/tests/divBuilder.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { divSpec, specToHtml, isValidDivString } from '../src/utils/divBuilder.js';
+
+const spec = divSpec({
+  className: 'outer',
+  children: [
+    divSpec({ className: 'inner' }),
+    divSpec({ className: 'second', children: [divSpec({ className: 'deep' })] })
+  ]
+});
+
+test('buildDiv produces balanced div structure', () => {
+  const html = specToHtml(spec);
+  assert.ok(isValidDivString(html));
+  const opens = (html.match(/<div/g) || []).length;
+  const closes = (html.match(/<\/div>/g) || []).length;
+  assert.equal(opens, closes);
+});


### PR DESCRIPTION
## Summary
- factor out div building helpers into `divBuilder.js`
- use the new helpers for the TaskManager login screen
- add unit test verifying generated div html is well formed

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test`
