### PR TITLE
Fix closing tags and expand div tests

### DIFF
--- a/frontend/src/components/TaskManager.jsx
+++ b/frontend/src/components/TaskManager.jsx
@@ -882,6 +882,7 @@ return (
       </div>
     </DragDropContext>
   </div>
+  </div>
 );
 };
 

--- a/frontend/src/utils/divBuilder.js
+++ b/frontend/src/utils/divBuilder.js
@@ -36,3 +36,17 @@ export function isValidDivString(html) {
   const close = (html.match(/<\/div>/g) || []).length;
   return open === close;
 }
+
+/** Build a nested chain of div specs */
+export function nestedDivSpec(depth) {
+  if (depth <= 0) return null;
+  return divSpec({ children: [nestedDivSpec(depth - 1)] });
+}
+
+/** Build a branching tree of div specs */
+export function branchingDivSpec(depth, breadth) {
+  if (depth <= 0) return null;
+  return divSpec({
+    children: Array.from({ length: breadth }, () => branchingDivSpec(depth - 1, breadth))
+  });
+}

--- a/frontend/tests/divBuilder.test.js
+++ b/frontend/tests/divBuilder.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { divSpec, specToHtml, isValidDivString } from '../src/utils/divBuilder.js';
+import { divSpec, specToHtml, isValidDivString, nestedDivSpec, branchingDivSpec } from '../src/utils/divBuilder.js';
 
 const spec = divSpec({
   className: 'outer',
@@ -16,4 +16,21 @@ test('buildDiv produces balanced div structure', () => {
   const opens = (html.match(/<div/g) || []).length;
   const closes = (html.match(/<\/div>/g) || []).length;
   assert.equal(opens, closes);
+});
+
+test('nestedDivSpec generates balanced HTML', () => {
+  const html = specToHtml(nestedDivSpec(5));
+  assert.ok(isValidDivString(html));
+});
+
+test('branchingDivSpec generates balanced HTML', () => {
+  const html = specToHtml(branchingDivSpec(3, 2));
+  const opens = (html.match(/<div/g) || []).length;
+  const closes = (html.match(/<\/div>/g) || []).length;
+  assert.ok(isValidDivString(html));
+  assert.equal(opens, closes);
+});
+
+test('isValidDivString detects imbalance', () => {
+  assert.equal(isValidDivString('<div><div></div>'), false);
 });

--- a/frontend/tests/jsx.test.js
+++ b/frontend/tests/jsx.test.js
@@ -16,3 +16,17 @@ test('TaskManager JSX fragments are balanced', () => {
   const closes = (src.match(/<\/>/g) || []).length;
   assert.equal(opens, closes);
 });
+
+test('TaskManager div tags are balanced', () => {
+  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const opens = (src.match(/<div[^>]*>/g) || []).length;
+  const closes = (src.match(/<\/div>/g) || []).length;
+  assert.equal(opens, closes);
+});
+
+test('DragDropContext tag closes properly', () => {
+  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const opens = (src.match(/<DragDropContext/g) || []).length;
+  const closes = (src.match(/<\/DragDropContext>/g) || []).length;
+  assert.equal(opens, closes);
+});


### PR DESCRIPTION
## Summary
- add utility functions `nestedDivSpec` and `branchingDivSpec`
- extend `divBuilder` tests for complex layouts and imbalance detection
- check `<div>` and `<DragDropContext>` balance in JSX tests
- close remaining div in `TaskManager` so counts match

## Testing
- `npm test --silent`
- `PYTHONPATH=. pytest -q`
