### PR TITLE
Refactor TaskManager into smaller components

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { Droppable, Draggable } from '@hello-pangea/dnd';
+import { ChevronDownIcon, ChevronRightIcon, Cross2Icon, PlusIcon, CheckIcon } from '@radix-ui/react-icons';
+import ReactMarkdown from 'react-markdown';
+
+const AreaList = ({
+  areas,
+  objectives,
+  collapsedAreas,
+  editingArea,
+  editingObjective,
+  editInputRef,
+  handleAreaClick,
+  toggleAreaCollapse,
+  handleAreaChange,
+  handleAreaBlur,
+  handleAreaKeyPress,
+  handleDeleteArea,
+  handleAddArea,
+  handleObjectiveClick,
+  handleObjectiveChange,
+  handleObjectiveBlur,
+  handleObjectiveKeyPress,
+  handleCompleteObjective,
+  handleDeleteObjective,
+  handleAddObjective
+}) => (
+  <div className="flex-1 border-b p-4 sm:p-8 mx-2 sm:mx-32 max-w-[1200px] sm:max-w-none mt-4">
+    <Droppable droppableId="areas-list-top" type="area">
+      {(provided) => (
+        <div
+          {...provided.droppableProps}
+          ref={provided.innerRef}
+          className="space-y-4"
+        >
+          {areas.map((area, index) => (
+            <Draggable key={area.key} draggableId={area.key} index={index}>
+              {(provided, snapshot) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.draggableProps}
+                  {...provided.dragHandleProps}
+                  className={`${snapshot.isDragging ? 'opacity-50' : ''}`}
+                >
+                  <div
+                    className="group flex items-center mb-2"
+                    onClick={(e) => handleAreaClick(area, e)}
+                  >
+                    <button
+                      onClick={(e) => { e.stopPropagation(); toggleAreaCollapse(area.key); }}
+                      className="mr-2"
+                    >
+                      {collapsedAreas.has(area.key) ? <ChevronRightIcon /> : <ChevronDownIcon />}
+                    </button>
+                    <div className="flex-grow flex items-center">
+                      {editingArea?.key === area.key ? (
+                        <input
+                          ref={editInputRef}
+                          value={editingArea.text}
+                          onChange={handleAreaChange}
+                          onBlur={handleAreaBlur}
+                          onKeyDown={handleAreaKeyPress}
+                          className="font-extrabold outline-none font-mate text-sm bg-transparent"
+                        />
+                      ) : (
+                        <>
+                          <ReactMarkdown
+                            className="font-extrabold"
+                            components={{ p: ({node, ...props}) => <span {...props} /> }}
+                          >
+                            {area.text || '_'}
+                          </ReactMarkdown>
+                          <Cross2Icon
+                            className="invisible group-hover:visible cursor-pointer ml-4 text-gray-400 hover:text-black delete-button h-3 w-3"
+                            onClick={(e) => handleDeleteArea(area.key, e)}
+                          />
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  {!collapsedAreas.has(area.key) && (
+                    <Droppable droppableId={area.key} type="objective">
+                      {(provided) => (
+                        <div
+                          {...provided.droppableProps}
+                          ref={provided.innerRef}
+                          className="pl-4 space-y-1"
+                        >
+                          {objectives
+                            .filter(obj => obj.area_key === area.key)
+                            .sort((a, b) => a.order_index - b.order_index)
+                            .map((objective, index) => (
+                              <Draggable
+                                key={objective.key}
+                                draggableId={objective.key}
+                                index={index}
+                              >
+                                {(provided, snapshot) => (
+                                  <div
+                                    ref={provided.innerRef}
+                                    {...provided.draggableProps}
+                                    {...provided.dragHandleProps}
+                                    className={`group flex items-center ${snapshot.isDragging ? 'opacity-50' : ''}`}
+                                    onClick={(e) => handleObjectiveClick(objective, e)}
+                                  >
+                                    <div className="flex-grow flex items-center">
+                                      {editingObjective?.key === objective.key ? (
+                                        <input
+                                          ref={editInputRef}
+                                          value={editingObjective.text}
+                                          onChange={handleObjectiveChange}
+                                          onBlur={handleObjectiveBlur}
+                                          onKeyDown={handleObjectiveKeyPress}
+                                          className="outline-none font-mate text-sm bg-transparent w-full"
+                                        />
+                                      ) : (
+                                        <>
+                                          <span className={`italic ${objective.status === 'complete' ? 'line-through' : ''}`}>
+                                            {index + 1}. <ReactMarkdown className="inline" components={{ p: ({node, ...props}) => <span {...props} /> }}>
+                                              {objective.text || '_'}
+                                            </ReactMarkdown>
+                                          </span>
+                                          <div className="invisible group-hover:visible flex items-center ml-4">
+                                            <CheckIcon
+                                              className="cursor-pointer text-gray-400 hover:text-black h-3 w-3 mr-2"
+                                              onClick={(e) => handleCompleteObjective(objective, e)}
+                                            />
+                                            <Cross2Icon
+                                              className="cursor-pointer text-gray-400 hover:text-black delete-button h-3 w-3"
+                                              onClick={(e) => handleDeleteObjective(objective.key, e)}
+                                            />
+                                          </div>
+                                        </>
+                                      )}
+                                    </div>
+                                  </div>
+                                )}
+                              </Draggable>
+                            ))}
+                          {provided.placeholder}
+                          <div className="group flex items-center">
+                            <PlusIcon
+                              className="invisible group-hover:visible cursor-pointer text-gray-400 hover:text-black add-button h-3 w-3"
+                              onClick={() => handleAddObjective(area.key)}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </Droppable>
+                  )}
+                </div>
+              )}
+            </Draggable>
+          ))}
+          {provided.placeholder}
+          <div className="mt-4 group flex items-center">
+            <PlusIcon
+              className="cursor-pointer text-gray-400 hover:text-black add-button h-3 w-3"
+              onClick={handleAddArea}
+            />
+          </div>
+        </div>
+      )}
+    </Droppable>
+  </div>
+);
+
+export default AreaList;

--- a/frontend/src/components/ObjectiveList.jsx
+++ b/frontend/src/components/ObjectiveList.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import TaskList from './TaskList';
+
+const ObjectiveList = ({
+  area,
+  objectives,
+  tasks,
+  editingTask,
+  editInputBottomRef,
+  handleTaskClick,
+  handleCompleteTask,
+  handleDeleteTask,
+  handleSecondaryTask,
+  handleTaskChange,
+  handleTaskBlur,
+  handleTaskKeyPress,
+  handleAddTask
+}) => (
+  <div className="pl-4 space-y-1">
+    {objectives
+      .filter(obj => obj.area_key === area.key)
+      .sort((a, b) => a.order_index - b.order_index)
+      .map((objective, index) => (
+        <div key={`bottom-${objective.key}`} className="group">
+          <div className="flex items-center italic">
+            <span className={objective.status === 'complete' ? 'line-through' : ''}>
+              {index + 1}. {objective.text}
+            </span>
+          </div>
+          <TaskList
+            tasks={tasks
+              .filter(task => task.objective_key === objective.key)
+              .sort((a, b) => a.order_index - b.order_index)}
+            parentId={objective.key}
+            parentType="objective"
+            editingTask={editingTask}
+            editInputBottomRef={editInputBottomRef}
+            handleTaskClick={handleTaskClick}
+            handleCompleteTask={handleCompleteTask}
+            handleDeleteTask={handleDeleteTask}
+            handleSecondaryTask={handleSecondaryTask}
+            handleTaskChange={handleTaskChange}
+            handleTaskBlur={handleTaskBlur}
+            handleTaskKeyPress={handleTaskKeyPress}
+            handleAddTask={handleAddTask}
+            className="pl-4 space-y-1 mt-1 mb-4"
+          />
+        </div>
+      ))}
+  </div>
+);
+
+export default ObjectiveList;

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Droppable } from '@hello-pangea/dnd';
+import { PlusIcon } from '@radix-ui/react-icons';
+import TaskItem from './TaskItem';
+
+const TaskList = ({
+  tasks,
+  parentId,
+  parentType,
+  editingTask,
+  editInputBottomRef,
+  handleTaskClick,
+  handleCompleteTask,
+  handleDeleteTask,
+  handleSecondaryTask,
+  handleTaskChange,
+  handleTaskBlur,
+  handleTaskKeyPress,
+  handleAddTask,
+  className = ''
+}) => (
+  <Droppable droppableId={`${parentId}-${parentType}`} type="task">
+    {(provided) => (
+      <div
+        {...provided.droppableProps}
+        ref={provided.innerRef}
+        className={className}
+      >
+        {tasks.map((task, index) => (
+          <TaskItem
+            key={`task-${task.key}`}
+            task={task}
+            index={index}
+            editing={editingTask?.key === task.key}
+            editingTask={editingTask}
+            onEdit={handleTaskClick}
+            onComplete={handleCompleteTask}
+            onDelete={handleDeleteTask}
+            onSecondary={handleSecondaryTask}
+            inputRef={editInputBottomRef}
+            onChange={handleTaskChange}
+            onBlur={() => handleTaskBlur(task)}
+            onKeyDown={handleTaskKeyPress}
+          />
+        ))}
+        {provided.placeholder}
+        <div className="group flex items-center">
+          <PlusIcon
+            className="invisible group-hover:visible cursor-pointer text-gray-400 hover:text-black add-button h-3 w-3"
+            onClick={() => handleAddTask(parentId, parentType)}
+          />
+        </div>
+      </div>
+    )}
+  </Droppable>
+);
+
+export default TaskList;

--- a/frontend/tests/basic.test.js
+++ b/frontend/tests/basic.test.js
@@ -38,8 +38,8 @@ test('main.jsx renders App inside StrictMode', () => {
 });
 
 test('TaskItem component is imported and defined', () => {
-  const managerSrc = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
-  assert.match(managerSrc, /from '.\/TaskItem'/);
+  const taskListSrc = readFileSync(resolve('src/components/TaskList.jsx'), 'utf8');
+  assert.match(taskListSrc, /from '.\/TaskItem'/);
 
   const itemSrc = readFileSync(resolve('src/components/TaskItem.jsx'), 'utf8');
   assert.match(itemSrc, /const TaskItem/);

--- a/frontend/tests/collapse.test.js
+++ b/frontend/tests/collapse.test.js
@@ -12,7 +12,11 @@ function resolve(relPath) {
 }
 
 test('TaskManager supports collapsing areas', () => {
-  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const files = [
+    'src/components/TaskManager.jsx',
+    'src/components/AreaList.jsx'
+  ];
+  const src = files.map(f => readFileSync(resolve(f), 'utf8')).join('\n');
   assert.match(src, /collapsedAreas/);
   assert.match(src, /useState\(/);
   assert.match(src, /new Set/);

--- a/frontend/tests/jsx.test.js
+++ b/frontend/tests/jsx.test.js
@@ -16,36 +16,46 @@ function checkBalanced(src, tag) {
   assert.equal(open, close);
 }
 
+function combinedSrc() {
+  const files = [
+    'src/components/TaskManager.jsx',
+    'src/components/AreaList.jsx',
+    'src/components/ObjectiveList.jsx',
+    'src/components/TaskList.jsx'
+  ];
+  return files.map(f => readFileSync(resolve(f), 'utf8')).join('\n');
+}
+
 test('TaskManager JSX fragments are balanced', () => {
-  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const src = combinedSrc();
   const opens = (src.match(/<>/g) || []).length;
   const closes = (src.match(/<\/>/g) || []).length;
   assert.equal(opens, closes);
 });
 
 test('TaskManager div tags are balanced', () => {
-  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const src = combinedSrc();
   const opens = (src.match(/<div[^>]*>/g) || []).length;
   const closes = (src.match(/<\/div>/g) || []).length;
   assert.equal(opens, closes);
 });
 
 test('DragDropContext tag closes properly', () => {
-  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const src = combinedSrc();
   checkBalanced(src, 'DragDropContext');
 });
 
 test('Droppable tags close properly', () => {
-  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const src = combinedSrc();
   checkBalanced(src, 'Droppable');
 });
 
 test('Draggable tags close properly', () => {
-  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const src = combinedSrc();
   checkBalanced(src, 'Draggable');
 });
 
 test('ReactMarkdown tags close properly', () => {
-  const src = readFileSync(resolve('src/components/TaskManager.jsx'), 'utf8');
+  const src = combinedSrc();
   checkBalanced(src, 'ReactMarkdown');
 });


### PR DESCRIPTION
## Summary
- split TaskManager return into AreaList, ObjectiveList and TaskList components
- replace inline markup in `TaskManager.jsx` with those components
- adjust tests to read new component files

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`