### PR TITLE
Combine area and task views

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -2,14 +2,18 @@ import React from 'react';
 import { Droppable, Draggable } from '@hello-pangea/dnd';
 import { ChevronDownIcon, ChevronRightIcon, Cross2Icon, PlusIcon, CheckIcon } from '@radix-ui/react-icons';
 import ReactMarkdown from 'react-markdown';
+import TaskList from './TaskList';
 
 const AreaList = ({
   areas,
   objectives,
+  tasks,
   collapsedAreas,
   editingArea,
   editingObjective,
+  editingTask,
   editInputRef,
+  editInputBottomRef,
   handleAreaClick,
   toggleAreaCollapse,
   handleAreaChange,
@@ -23,7 +27,15 @@ const AreaList = ({
   handleObjectiveKeyPress,
   handleCompleteObjective,
   handleDeleteObjective,
-  handleAddObjective
+  handleAddObjective,
+  handleTaskClick,
+  handleCompleteTask,
+  handleDeleteTask,
+  handleSecondaryTask,
+  handleTaskChange,
+  handleTaskBlur,
+  handleTaskKeyPress,
+  handleAddTask
 }) => (
   <div className="flex-1 border-b p-4 sm:p-8 mx-2 sm:mx-32 max-w-[1200px] sm:max-w-none mt-4">
     <Droppable droppableId="areas-list-top" type="area">
@@ -79,13 +91,14 @@ const AreaList = ({
                     </div>
                   </div>
                   {!collapsedAreas.has(area.key) && (
-                    <Droppable droppableId={area.key} type="objective">
-                      {(provided) => (
-                        <div
-                          {...provided.droppableProps}
-                          ref={provided.innerRef}
-                          className="pl-4 space-y-1"
-                        >
+                    <>
+                      <Droppable droppableId={area.key} type="objective">
+                        {(provided) => (
+                          <div
+                            {...provided.droppableProps}
+                            ref={provided.innerRef}
+                            className="pl-4 space-y-1"
+                          >
                           {objectives
                             .filter(obj => obj.area_key === area.key)
                             .sort((a, b) => a.order_index - b.order_index)
@@ -99,40 +112,62 @@ const AreaList = ({
                                   <div
                                     ref={provided.innerRef}
                                     {...provided.draggableProps}
-                                    {...provided.dragHandleProps}
-                                    className={`group flex items-center ${snapshot.isDragging ? 'opacity-50' : ''}`}
-                                    onClick={(e) => handleObjectiveClick(objective, e)}
+                                    className={`${snapshot.isDragging ? 'opacity-50' : ''}`}
                                   >
-                                    <div className="flex-grow flex items-center">
-                                      {editingObjective?.key === objective.key ? (
-                                        <input
-                                          ref={editInputRef}
-                                          value={editingObjective.text}
-                                          onChange={handleObjectiveChange}
-                                          onBlur={handleObjectiveBlur}
-                                          onKeyDown={handleObjectiveKeyPress}
-                                          className="outline-none font-mate text-sm bg-transparent w-full"
-                                        />
-                                      ) : (
-                                        <>
-                                          <span className={`italic ${objective.status === 'complete' ? 'line-through' : ''}`}>
-                                            {index + 1}. <ReactMarkdown className="inline" components={{ p: ({node, ...props}) => <span {...props} /> }}>
-                                              {objective.text || '_'}
-                                            </ReactMarkdown>
-                                          </span>
-                                          <div className="invisible group-hover:visible flex items-center ml-4">
-                                            <CheckIcon
-                                              className="cursor-pointer text-gray-400 hover:text-black h-3 w-3 mr-2"
-                                              onClick={(e) => handleCompleteObjective(objective, e)}
-                                            />
-                                            <Cross2Icon
-                                              className="cursor-pointer text-gray-400 hover:text-black delete-button h-3 w-3"
-                                              onClick={(e) => handleDeleteObjective(objective.key, e)}
-                                            />
-                                          </div>
-                                        </>
-                                      )}
+                                    <div
+                                      {...provided.dragHandleProps}
+                                      className="group flex items-center"
+                                      onClick={(e) => handleObjectiveClick(objective, e)}
+                                    >
+                                      <div className="flex-grow flex items-center">
+                                        {editingObjective?.key === objective.key ? (
+                                          <input
+                                            ref={editInputRef}
+                                            value={editingObjective.text}
+                                            onChange={handleObjectiveChange}
+                                            onBlur={handleObjectiveBlur}
+                                            onKeyDown={handleObjectiveKeyPress}
+                                            className="outline-none font-mate text-sm bg-transparent w-full"
+                                          />
+                                        ) : (
+                                          <>
+                                            <span className={`italic ${objective.status === 'complete' ? 'line-through' : ''}`}>
+                                              {index + 1}. <ReactMarkdown className="inline" components={{ p: ({node, ...props}) => <span {...props} /> }}>
+                                                {objective.text || '_'}
+                                              </ReactMarkdown>
+                                            </span>
+                                            <div className="invisible group-hover:visible flex items-center ml-4">
+                                              <CheckIcon
+                                                className="cursor-pointer text-gray-400 hover:text-black h-3 w-3 mr-2"
+                                                onClick={(e) => handleCompleteObjective(objective, e)}
+                                              />
+                                              <Cross2Icon
+                                                className="cursor-pointer text-gray-400 hover:text-black delete-button h-3 w-3"
+                                                onClick={(e) => handleDeleteObjective(objective.key, e)}
+                                              />
+                                            </div>
+                                          </>
+                                        )}
+                                      </div>
                                     </div>
+                                    <TaskList
+                                      tasks={tasks
+                                        .filter(task => task.objective_key === objective.key)
+                                        .sort((a, b) => a.order_index - b.order_index)}
+                                      parentId={objective.key}
+                                      parentType="objective"
+                                      editingTask={editingTask}
+                                      editInputBottomRef={editInputBottomRef}
+                                      handleTaskClick={handleTaskClick}
+                                      handleCompleteTask={handleCompleteTask}
+                                      handleDeleteTask={handleDeleteTask}
+                                      handleSecondaryTask={handleSecondaryTask}
+                                      handleTaskChange={handleTaskChange}
+                                      handleTaskBlur={handleTaskBlur}
+                                      handleTaskKeyPress={handleTaskKeyPress}
+                                      handleAddTask={handleAddTask}
+                                      className="pl-4 space-y-1 mt-1 mb-4"
+                                    />
                                   </div>
                                 )}
                               </Draggable>
@@ -146,7 +181,26 @@ const AreaList = ({
                           </div>
                         </div>
                       )}
-                    </Droppable>
+                      </Droppable>
+                      <TaskList
+                        tasks={tasks
+                          .filter((task) => task.area_key === area.key)
+                          .sort((a, b) => a.order_index - b.order_index)}
+                        parentId={area.key}
+                        parentType="area"
+                        editingTask={editingTask}
+                        editInputBottomRef={editInputBottomRef}
+                        handleTaskClick={handleTaskClick}
+                        handleCompleteTask={handleCompleteTask}
+                        handleDeleteTask={handleDeleteTask}
+                        handleSecondaryTask={handleSecondaryTask}
+                        handleTaskChange={handleTaskChange}
+                        handleTaskBlur={handleTaskBlur}
+                        handleTaskKeyPress={handleTaskKeyPress}
+                        handleAddTask={handleAddTask}
+                        className="space-y-1 mt-4"
+                      />
+                    </>
                   )}
                 </div>
               )}

--- a/frontend/src/components/TaskManager.jsx
+++ b/frontend/src/components/TaskManager.jsx
@@ -1,9 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { DragDropContext } from '@hello-pangea/dnd';
 import AreaList from './AreaList';
-import ObjectiveList from './ObjectiveList';
-import TaskList from './TaskList';
-import { ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons';
 import { v4 as uuidv4 } from 'uuid';
 import apiWrapper from '../api';
 import ReactMarkdown from 'react-markdown';
@@ -619,10 +616,13 @@ return (
       <AreaList
         areas={areas}
         objectives={objectives}
+        tasks={tasks}
         collapsedAreas={collapsedAreas}
         editingArea={editingArea}
         editingObjective={editingObjective}
+        editingTask={editingTask}
         editInputRef={editInputRef}
+        editInputBottomRef={editInputBottomRef}
         handleAreaClick={handleAreaClick}
         toggleAreaCollapse={toggleAreaCollapse}
         handleAreaChange={handleAreaChange}
@@ -637,57 +637,15 @@ return (
         handleCompleteObjective={handleCompleteObjective}
         handleDeleteObjective={handleDeleteObjective}
         handleAddObjective={handleAddObjective}
+        handleTaskClick={handleTaskClick}
+        handleCompleteTask={handleCompleteTask}
+        handleDeleteTask={handleDeleteTask}
+        handleSecondaryTask={handleSecondaryTask}
+        handleTaskChange={handleTaskChange}
+        handleTaskBlur={handleTaskBlur}
+        handleTaskKeyPress={handleTaskKeyPress}
+        handleAddTask={handleAddTask}
       />
-
-      <div className="flex-1 p-4 sm:p-8 mx-2 sm:mx-32 max-w-[1200px] sm:max-w-none">
-        {areas.map((area) => (
-          <div key={`bottom-${area.key}`} className="space-y-4">
-            <div className="font-extrabold mb-2 flex items-center">
-              <button onClick={() => toggleAreaCollapse(area.key)} className="mr-2">
-                {collapsedAreas.has(area.key) ? <ChevronRightIcon /> : <ChevronDownIcon />}
-              </button>
-              {area.text}
-            </div>
-            {!collapsedAreas.has(area.key) && (
-              <div className="pl-4 space-y-1">
-                <ObjectiveList
-                  area={area}
-                  objectives={objectives}
-                  tasks={tasks}
-                  editingTask={editingTask}
-                  editInputBottomRef={editInputBottomRef}
-                  handleTaskClick={handleTaskClick}
-                  handleCompleteTask={handleCompleteTask}
-                  handleDeleteTask={handleDeleteTask}
-                  handleSecondaryTask={handleSecondaryTask}
-                  handleTaskChange={handleTaskChange}
-                  handleTaskBlur={handleTaskBlur}
-                  handleTaskKeyPress={handleTaskKeyPress}
-                  handleAddTask={handleAddTask}
-                />
-                <TaskList
-                  tasks={tasks
-                    .filter((task) => task.area_key === area.key)
-                    .sort((a, b) => a.order_index - b.order_index)}
-                  parentId={area.key}
-                  parentType="area"
-                  editingTask={editingTask}
-                  editInputBottomRef={editInputBottomRef}
-                  handleTaskClick={handleTaskClick}
-                  handleCompleteTask={handleCompleteTask}
-                  handleDeleteTask={handleDeleteTask}
-                  handleSecondaryTask={handleSecondaryTask}
-                  handleTaskChange={handleTaskChange}
-                  handleTaskBlur={handleTaskBlur}
-                  handleTaskKeyPress={handleTaskKeyPress}
-                  handleAddTask={handleAddTask}
-                  className="space-y-1 mt-4"
-                />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
     </DragDropContext>
   </div>
 );


### PR DESCRIPTION
## Summary
- combine the top and bottom sections into a single AreaList view
- pass tasks and handlers through AreaList so objectives show their tasks too
- remove unused ObjectiveList/TaskList imports from TaskManager

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test`