### PR TITLE
Add frontend flow tests and improve undo behavior

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -84,7 +84,7 @@ def handle_areas():
             with get_db() as conn:
                 # Get max order_index
                 max_order = conn.execute('SELECT MAX(order_index) FROM areas').fetchone()[0]
-                next_order = (max_order or -1) + 1
+                next_order = (max_order if max_order is not None else -1) + 1
                 
                 conn.execute(
                     'INSERT INTO areas (key, text, date_time_created, order_index) VALUES (?, ?, ?, ?)',
@@ -150,19 +150,20 @@ def handle_area(key):
             with get_db() as conn:
                 # Log current state of area and its children for undo
                 area = conn.execute('SELECT * FROM areas WHERE key = ?', (key,)).fetchone()
-                if area:
-                    log_action_for_undo(conn, 'DELETE', 'areas', key, dict(area))
-                    
+
                 objectives = conn.execute('SELECT * FROM objectives WHERE area_key = ?', (key,)).fetchall()
                 for obj in objectives:
-                    log_action_for_undo(conn, 'DELETE', 'objectives', obj['key'], dict(obj))
                     tasks = conn.execute('SELECT * FROM tasks WHERE objective_key = ?', (obj['key'],)).fetchall()
                     for task in tasks:
                         log_action_for_undo(conn, 'DELETE', 'tasks', task['key'], dict(task))
+                    log_action_for_undo(conn, 'DELETE', 'objectives', obj['key'], dict(obj))
 
                 area_tasks = conn.execute('SELECT * FROM tasks WHERE area_key = ?', (key,)).fetchall()
                 for task in area_tasks:
                     log_action_for_undo(conn, 'DELETE', 'tasks', task['key'], dict(task))
+
+                if area:
+                    log_action_for_undo(conn, 'DELETE', 'areas', key, dict(area))
 
                 conn.execute('DELETE FROM areas WHERE key = ?', (key,))
                 conn.commit()
@@ -195,7 +196,7 @@ def handle_objectives():
                     'SELECT MAX(order_index) FROM objectives WHERE area_key = ?',
                     (data['area_key'],)
                 ).fetchone()[0]
-                next_order = (max_order or -1) + 1
+                next_order = (max_order if max_order is not None else -1) + 1
                 
                 conn.execute(
                     'INSERT INTO objectives (key, area_key, text, date_time_created, status, order_index) VALUES (?, ?, ?, ?, ?, ?)',
@@ -312,11 +313,11 @@ def handle_objective(key):
                 # Log current state for undo
                 objective = conn.execute('SELECT * FROM objectives WHERE key = ?', (key,)).fetchone()
                 if objective:
-                    log_action_for_undo(conn, 'DELETE', 'objectives', key, dict(objective))
-                    # Log child tasks
+                    # Log child tasks before the objective so undo restores in correct order
                     tasks = conn.execute('SELECT * FROM tasks WHERE objective_key = ?', (key,)).fetchall()
                     for task in tasks:
                         log_action_for_undo(conn, 'DELETE', 'tasks', task['key'], dict(task))
+                    log_action_for_undo(conn, 'DELETE', 'objectives', key, dict(objective))
 
                 conn.execute('DELETE FROM objectives WHERE key = ?', (key,))
                 conn.commit()
@@ -381,7 +382,7 @@ def handle_tasks():
                     f'SELECT MAX(order_index) FROM tasks WHERE {parent_type} = ?',
                     (parent_key,)
                 ).fetchone()[0]
-                next_order = (max_order or -1) + 1
+                next_order = (max_order if max_order is not None else -1) + 1
                 
                 conn.execute(
                     '''INSERT INTO tasks (
@@ -622,13 +623,21 @@ def undo_last_action():
             if action_data['action_type'] == 'DELETE':
                 if action_data['table_name'] == 'areas':
                     conn.execute(
+                        'UPDATE areas SET order_index = order_index + 1 WHERE order_index >= ?',
+                        (old_data['order_index'],)
+                    )
+                    conn.execute(
                         'INSERT INTO areas (key, text, order_index, date_time_created) VALUES (?, ?, ?, ?)',
                         (old_data['key'], old_data['text'], old_data['order_index'], old_data['date_time_created'])
                     )
                 elif action_data['table_name'] == 'objectives':
+                    conn.execute(
+                        'UPDATE objectives SET order_index = order_index + 1 WHERE area_key = ? AND order_index >= ?',
+                        (old_data['area_key'], old_data['order_index'])
+                    )
                     conn.execute('''
                         INSERT INTO objectives (
-                            key, area_key, text, order_index, date_time_created, 
+                            key, area_key, text, order_index, date_time_created,
                             date_time_completed, status
                         ) VALUES (?, ?, ?, ?, ?, ?, ?)
                     ''', (
@@ -637,6 +646,12 @@ def undo_last_action():
                         old_data['date_time_completed'], old_data['status']
                     ))
                 elif action_data['table_name'] == 'tasks':
+                    parent_col = 'area_key' if old_data['area_key'] else 'objective_key'
+                    parent_key = old_data['area_key'] or old_data['objective_key']
+                    conn.execute(
+                        f'UPDATE tasks SET order_index = order_index + 1 WHERE {parent_col} = ? AND order_index >= ?',
+                        (parent_key, old_data['order_index'])
+                    )
                     conn.execute('''
                         INSERT INTO tasks (
                             key, area_key, objective_key, text, order_index,

--- a/backend/database.py
+++ b/backend/database.py
@@ -85,6 +85,8 @@ def get_db():
     print(f"Attempting to connect to DB at: {DB_PATH}")
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
+    # enable foreign key constraints for cascading deletes
+    conn.execute('PRAGMA foreign_keys = ON')
     return conn
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,6 +64,7 @@ class APITestCase(unittest.TestCase):
         def get_test_db():
             conn = sqlite3.connect(self.db_path)
             conn.row_factory = sqlite3.Row
+            conn.execute('PRAGMA foreign_keys = ON')
             return conn
         app.get_db = get_test_db
 
@@ -204,6 +205,60 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         area = self.client.get('/api/areas').get_json()[0]
         self.assertEqual(area['text'], 'Area 1')
+
+    def test_full_frontend_flow(self):
+        c = self.client
+        # create initial data like the frontend would
+        c.post('/api/areas', json={"key": "area1", "text": "Area 1"})
+        c.post('/api/objectives', json={"key": "o1", "area_key": "area1", "text": "Objective 1"})
+        c.post('/api/objectives', json={"key": "o2", "area_key": "area1", "text": "Objective 2"})
+        c.post('/api/tasks', json={"key": "t1", "text": "Task 1", "objective_key": "o1"})
+        c.post('/api/tasks', json={"key": "t2", "text": "Task 2", "objective_key": "o1"})
+
+        # verify structure
+        self.assertEqual([o['key'] for o in c.get('/api/objectives').get_json()], ['o1', 'o2'])
+        tasks = sorted([t for t in c.get('/api/tasks').get_json() if t['objective_key'] == 'o1'], key=lambda x: x['order_index'])
+        self.assertEqual([t['key'] for t in tasks], ['t1', 't2'])
+        self.assertEqual([t['order_index'] for t in tasks], [0, 1])
+
+        # delete a task (clicking x)
+        c.delete('/api/tasks/t1')
+        tasks = [t['key'] for t in c.get('/api/tasks').get_json() if t['objective_key'] == 'o1']
+        self.assertEqual(tasks, ['t2'])
+
+        # undo deletion
+        c.post('/api/undo')
+        tasks = sorted([t for t in c.get('/api/tasks').get_json() if t['objective_key'] == 'o1'], key=lambda x: x['order_index'])
+        self.assertEqual([t['key'] for t in tasks], ['t1', 't2'])
+        self.assertEqual([t['order_index'] for t in tasks], [0, 1])
+
+        # delete objective with children
+        c.delete('/api/objectives/o1')
+        self.assertEqual([o['key'] for o in c.get('/api/objectives').get_json()], ['o2'])
+        self.assertEqual([t for t in c.get('/api/tasks').get_json() if t['objective_key'] == 'o1'], [])
+
+        # undo objective deletion (needs 3 undos: two tasks then objective)
+        c.post('/api/undo')
+        c.post('/api/undo')
+        c.post('/api/undo')
+        self.assertEqual(sorted(o['key'] for o in c.get('/api/objectives').get_json()), ['o1', 'o2'])
+        tasks = sorted([t for t in c.get('/api/tasks').get_json() if t['objective_key'] == 'o1'], key=lambda x: x['order_index'])
+        self.assertEqual([t['key'] for t in tasks], ['t1', 't2'])
+
+        # delete entire area
+        c.delete('/api/areas/area1')
+        self.assertEqual(c.get('/api/areas').get_json(), [])
+        self.assertEqual(c.get('/api/objectives').get_json(), [])
+        self.assertEqual(c.get('/api/tasks').get_json(), [])
+
+        # undo area deletion (area + 2 objectives + 2 tasks = 5 undos)
+        for _ in range(5):
+            c.post('/api/undo')
+
+        self.assertEqual([a['key'] for a in c.get('/api/areas').get_json()], ['area1'])
+        self.assertEqual(sorted(o['key'] for o in c.get('/api/objectives').get_json()), ['o1', 'o2'])
+        all_tasks = sorted(c.get('/api/tasks').get_json(), key=lambda x: (x['objective_key'], x['order_index']))
+        self.assertEqual([t['key'] for t in all_tasks], ['t1', 't2'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- enable foreign key enforcement when creating DB connections
- fix order index calculation when creating areas, objectives and tasks
- adjust undo logic so insertions maintain ordering
- log deletes in an order that supports FK constraints
- add an integration-style test covering a full frontend workflow

## Testing
- `PYTHONPATH=. pytest -q`
- `cd frontend && npm test --silent`