### PR TITLE
Handle invalid json

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -6,7 +6,9 @@ def parse_json(required_fields=None):
     if not request.is_json:
         return None, (jsonify({"error": "Content-Type must be application/json"}), 400)
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if data is None:
+        return None, (jsonify({"error": "Invalid JSON"}), 400)
     if required_fields:
         missing = [f for f in required_fields if f not in data]
         if missing:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -180,6 +180,11 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertIn('Exactly one of area_key or objective_key', resp.get_json()['error'])
 
+    def test_invalid_json(self):
+        resp = self.client.post('/api/areas', data='{', headers={'Content-Type': 'application/json'})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('Invalid JSON', resp.get_json()['error'])
+
     def test_undo_without_actions(self):
         resp = self.client.post('/api/undo')
         self.assertEqual(resp.status_code, 404)


### PR DESCRIPTION
## Summary
- validate JSON input and return a 400 instead of raising an exception
- cover bad JSON with a backend test

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test` *(fails: Could not read package.json)*