### PR TITLE
Remove redundant after_request, add CORS tests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -45,20 +45,6 @@ CORS(app,
 with app.app_context():
     init_db()
 
-
-@app.after_request
-def after_request(response):
-    origin = request.headers.get('Origin')
-    if origin in [
-        "http://localhost:5173",
-        "https://bigpicture-frontend-ancient-night-2172.fly.dev"
-    ]:
-        response.headers.add('Access-Control-Allow-Origin', origin)
-        response.headers.add('Access-Control-Allow-Headers', 'Content-Type')
-        response.headers.add('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
-        response.headers.add('Access-Control-Allow-Credentials', 'true')
-    return response
-
 @app.route('/api/test', methods=['GET'])
 def test():
     return jsonify({"status": "ok", "message": "API is working"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -205,5 +205,22 @@ class APITestCase(unittest.TestCase):
         area = self.client.get('/api/areas').get_json()[0]
         self.assertEqual(area['text'], 'Area 1')
 
+    def test_cors_headers_allowed_origin(self):
+        resp = self.client.get('/api/test', headers={'Origin': 'http://localhost:5173'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get('Access-Control-Allow-Origin'), 'http://localhost:5173')
+        self.assertEqual(resp.headers.get('Access-Control-Allow-Credentials'), 'true')
+
+        resp = self.client.open('/api/test', method='OPTIONS', headers={
+            'Origin': 'http://localhost:5173',
+            'Access-Control-Request-Method': 'GET',
+            'Access-Control-Request-Headers': 'Content-Type'
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get('Access-Control-Allow-Origin'), 'http://localhost:5173')
+        allow_headers = resp.headers.get('Access-Control-Allow-Headers')
+        self.assertIsNotNone(allow_headers)
+        self.assertIn('Content-Type', allow_headers)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- rely on Flask-CORS for handling CORS
- add regression test verifying CORS headers

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test`