### PR TITLE
Fix running backend directly

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -49,7 +49,10 @@ def create_app() -> Flask:
     with app.app_context():
         init_db()
 
-    from .routes import register_routes
+    try:
+        from .routes import register_routes
+    except ImportError:  # pragma: no cover - executed only when run as script
+        from routes import register_routes
 
     register_routes(app)
     return app


### PR DESCRIPTION
## Summary
- handle ImportError when importing `backend.routes` in `create_app`
- keep functional when running as script

## Testing
- `PYTHONPATH=. pytest -q`
- `cd frontend && npm test`