### PR TITLE
Centralize logging setup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 """Flask application entry point."""
 import os
 import logging
+logging.basicConfig(level=logging.INFO)
 from flask import Flask, jsonify
 from flask_cors import CORS
 
@@ -14,7 +15,6 @@ except ImportError:  # pragma: no cover - executed only when run as script
     from routes import areas, objectives, tasks, undo
 
 app = Flask(__name__)
-logging.basicConfig(level=logging.INFO)
 
 app.config['CORS_HEADERS'] = 'Content-Type'
 CORS(

--- a/backend/database.py
+++ b/backend/database.py
@@ -7,7 +7,6 @@ import pytz
 
 # Determine where the SQLite database should live. This mirrors the old logic in app.py
 DB_PATH = os.environ.get('DATABASE_URL', 'tasks.db')
-logging.basicConfig(level=logging.INFO)
 
 
 def get_pacific_time():


### PR DESCRIPTION
## Summary
- set up logging at the top of `app.py`
- remove separate `basicConfig` from `database.py`

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test`