### PR TITLE
Add add-area button when list empty

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -206,6 +206,14 @@ const AreaList = ({
               )}
             </Draggable>
           ))}
+          {areas.length === 0 && (
+            <div className="flex justify-center">
+              <PlusIcon
+                className="cursor-pointer text-gray-400 hover:text-black add-button h-4 w-4"
+                onClick={handleAddArea}
+              />
+            </div>
+          )}
           {provided.placeholder}
         </div>
       )}

--- a/frontend/tests/addAreaButton.test.js
+++ b/frontend/tests/addAreaButton.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+function resolve(relPath) {
+  return path.join(__dirname, '..', relPath);
+}
+
+const src = readFileSync(resolve('src/components/AreaList.jsx'), 'utf8');
+
+test('shows add area button when list is empty', () => {
+  assert.match(src, /areas\.length === 0/);
+  assert.match(src, /<PlusIcon[^>]*onClick={handleAddArea}/);
+});


### PR DESCRIPTION
## Summary
- show an always-visible '+' icon when no areas exist
- verify with an automated test

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test --silent`