### PR TITLE
Fix bottom plus adding area

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -216,15 +216,13 @@ const AreaList = ({
               )}
             </Draggable>
           ))}
-          {areas.length === 0 && (
-            <div className="flex justify-center">
-              <PlusIcon
-                className="cursor-pointer text-gray-400 hover:text-black add-button h-4 w-4"
-                onClick={handleAddArea}
-              />
-            </div>
-          )}
           {provided.placeholder}
+          <div className="flex justify-center mt-2">
+            <PlusIcon
+              className="cursor-pointer text-gray-400 hover:text-black add-button h-4 w-4"
+              onClick={handleAddArea}
+            />
+          </div>
         </div>
       )}
     </Droppable>

--- a/frontend/tests/addAreaButton.test.js
+++ b/frontend/tests/addAreaButton.test.js
@@ -12,7 +12,6 @@ function resolve(relPath) {
 
 const src = readFileSync(resolve('src/components/AreaList.jsx'), 'utf8');
 
-test('shows add area button when list is empty', () => {
-  assert.match(src, /areas\.length === 0/);
+test('shows add area button', () => {
   assert.match(src, /<PlusIcon[^>]*onClick={handleAddArea}/);
 });


### PR DESCRIPTION
## Summary
- always render the add-area button at the end of the list
- update test

## Testing
- `PYTHONPATH=. pytest -q`
- `npm --prefix frontend test --silent`
