### PR TITLE
Fix Add Area button placement

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -225,6 +225,14 @@ const AreaList = ({
             </div>
           )}
           {provided.placeholder}
+          {areas.length > 0 && (
+            <div className="flex justify-center">
+              <PlusIcon
+                className="cursor-pointer text-gray-400 hover:text-black add-button h-4 w-4"
+                onClick={handleAddArea}
+              />
+            </div>
+          )}
         </div>
       )}
     </Droppable>


### PR DESCRIPTION
## Summary
- always show the Add Area button after the list
- keep existing check for an empty list for test compatibility

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test --silent`