### PR TITLE
Fix empty items on outside click

### DIFF
--- a/frontend/src/components/TaskManager.jsx
+++ b/frontend/src/components/TaskManager.jsx
@@ -167,6 +167,21 @@ const handleAreaClick = (area, event, isBottom = false) => {
     }
   };
 
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      const inputElems = [editInputRef.current, editInputBottomRef.current];
+      const clickedInsideInput = inputElems.some((el) => el && el.contains(e.target));
+      const clickedButton = e.target.closest('.add-button') || e.target.closest('.delete-button');
+      if (!clickedInsideInput && !clickedButton) {
+        finalizeEditing();
+      }
+    };
+    if (editingArea || editingObjective || editingTask) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [editingArea, editingObjective, editingTask]);
+
   const handleAddArea = async () => {
     try {
       await finalizeEditing();


### PR DESCRIPTION
## Summary
- remove new empty area/objective/task if focus lost without typing

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`