### PR TITLE
Trim text on undo

### DIFF
--- a/backend/routes/undo.py
+++ b/backend/routes/undo.py
@@ -18,6 +18,8 @@ def undo_last_action():
                 return jsonify({"error": "No actions to undo"}), 404
             action_data = dict(last_action)
             old_data = json.loads(action_data['old_data'])
+            if 'text' in old_data:
+                old_data['text'] = old_data['text'].strip()
             if action_data['action_type'] == 'DELETE':
                 if action_data['table_name'] == 'areas':
                     conn.execute(
@@ -62,6 +64,10 @@ def undo_last_action():
                         'UPDATE areas SET text = ?, order_index = ? WHERE key = ?',
                         (old_data['text'], old_data['order_index'], old_data['key'])
                     )
+                    if old_data['text'] == '':
+                        related = conn.execute('SELECT 1 FROM objectives WHERE area_key = ? LIMIT 1', (old_data['key'],)).fetchone()
+                        if not related:
+                            conn.execute('DELETE FROM areas WHERE key = ?', (old_data['key'],))
                 elif action_data['table_name'] == 'objectives':
                     conn.execute(
                         'UPDATE objectives SET text = ?, area_key = ?, order_index = ?, status = ?, date_time_completed = ? WHERE key = ?',
@@ -70,6 +76,10 @@ def undo_last_action():
                             old_data['status'], old_data['date_time_completed'], old_data['key']
                         )
                     )
+                    if old_data['text'] == '':
+                        related = conn.execute('SELECT 1 FROM tasks WHERE objective_key = ? LIMIT 1', (old_data['key'],)).fetchone()
+                        if not related:
+                            conn.execute('DELETE FROM objectives WHERE key = ?', (old_data['key'],))
                 elif action_data['table_name'] == 'tasks':
                     conn.execute(
                         'UPDATE tasks SET text = ?, area_key = ?, objective_key = ?, order_index = ?, status = ?, date_time_completed = ? WHERE key = ?',
@@ -79,6 +89,11 @@ def undo_last_action():
                             old_data['key']
                         )
                     )
+                    if old_data['text'] == '':
+                        parent_col = 'area_key' if old_data['area_key'] else 'objective_key'
+                        parent_key = old_data['area_key'] or old_data['objective_key']
+                        app_module.shift_tasks_after_delete(conn, parent_col, parent_key, old_data['order_index'])
+                        conn.execute('DELETE FROM tasks WHERE key = ?', (old_data['key'],))
             conn.execute('DELETE FROM undo_log WHERE id = ?', (action_data['id'],))
             conn.commit()
             return jsonify({'status': 'success'})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,6 +214,25 @@ class APITestCase(unittest.TestCase):
         area = self.client.get('/api/areas').get_json()[0]
         self.assertEqual(area['text'], 'Area 1')
 
+    def test_undo_update_removes_blank_records(self):
+        # create area/objective/task with whitespace text
+        self.client.post('/api/areas', json={"key": "a1", "text": " "})
+        self.client.post('/api/objectives', json={"key": "o1", "area_key": "a1", "text": " "})
+        self.client.post('/api/tasks', json={"key": "t1", "text": " ", "objective_key": "o1"})
+
+        # update texts so they are not blank
+        self.client.patch('/api/areas/a1', json={"text": "x"})
+        self.client.patch('/api/objectives/o1', json={"text": "y"})
+        self.client.patch('/api/tasks/t1', json={"text": "z"})
+
+        # undo updates, which should trim and remove empty entries
+        self.client.post('/api/undo')  # undo task update
+        self.assertEqual(self.client.get('/api/tasks').get_json(), [])
+        self.client.post('/api/undo')  # undo objective update
+        self.assertEqual(self.client.get('/api/objectives').get_json(), [])
+        self.client.post('/api/undo')  # undo area update
+        self.assertEqual(self.client.get('/api/areas').get_json(), [])
+
     def test_cors_headers_allowed_origin(self):
         resp = self.client.get('/api/test', headers={'Origin': 'http://localhost:5173'})
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- trim text fields during undo actions
- remove areas, objectives, or tasks if the undone text becomes empty
- test undo removal of blank items

## Testing
- `PYTHONPATH=. pytest -q`
- `cd frontend && npm test`