### PR TITLE
Hide collapse chevrons until hover

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -62,7 +62,7 @@ const AreaList = ({
                   >
                     <button
                       onClick={(e) => { e.stopPropagation(); toggleAreaCollapse(area.key); }}
-                      className="mr-2"
+                      className="mr-2 invisible group-hover:visible"
                     >
                       {collapsedAreas.has(area.key) ? <ChevronRightIcon /> : <ChevronDownIcon />}
                     </button>
@@ -123,7 +123,7 @@ const AreaList = ({
                                     >
                                       <button
                                         onClick={(e) => { e.stopPropagation(); toggleObjectiveCollapse(objective.key); }}
-                                        className="mr-2"
+                                        className="mr-2 invisible group-hover:visible"
                                       >
                                         {collapsedObjectives.has(objective.key) ? <ChevronRightIcon /> : <ChevronDownIcon />}
                                       </button>


### PR DESCRIPTION
## Summary
- hide area/objective collapse chevron buttons until hovering

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test --silent`
