### PR TITLE
Fix chevron color for expanded areas

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -62,7 +62,7 @@ const AreaList = ({
                   >
                     <button
                       onClick={(e) => { e.stopPropagation(); toggleAreaCollapse(area.key); }}
-                      className="mr-2 invisible group-hover:visible cursor-pointer text-gray-400 hover:text-black"
+                      className={`mr-2 invisible group-hover:visible cursor-pointer hover:text-black ${collapsedAreas.has(area.key) ? 'text-gray-400' : 'text-black'}`}
                     >
                       {collapsedAreas.has(area.key) ? (
                         <ChevronRightIcon className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- show black chevron when an area is expanded

## Testing
- `PYTHONPATH=. pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683a34030ee8832a9198187abff6307d