### PR TITLE
Fix visibility of expansion chevrons

### DIFF
--- a/frontend/src/components/AreaList.jsx
+++ b/frontend/src/components/AreaList.jsx
@@ -62,7 +62,9 @@ const AreaList = ({
                   >
                     <button
                       onClick={(e) => { e.stopPropagation(); toggleAreaCollapse(area.key); }}
-                      className={`mr-2 invisible group-hover:visible cursor-pointer hover:text-black ${collapsedAreas.has(area.key) ? 'text-gray-400' : 'text-black'}`}
+                      className={`mr-2 cursor-pointer hover:text-black ${collapsedAreas.has(area.key)
+                        ? 'invisible group-hover:visible text-gray-400'
+                        : 'text-black'}`}
                     >
                       {collapsedAreas.has(area.key) ? (
                         <ChevronRightIcon className="h-3 w-3" />
@@ -131,7 +133,9 @@ const AreaList = ({
                                     >
                                       <button
                                         onClick={(e) => { e.stopPropagation(); toggleObjectiveCollapse(objective.key); }}
-                                        className={`mr-2 invisible group-hover:visible cursor-pointer hover:text-black ${collapsedObjectives.has(objective.key) ? 'text-gray-400' : 'text-black'}`}
+                                        className={`mr-2 cursor-pointer hover:text-black ${collapsedObjectives.has(objective.key)
+                                          ? 'invisible group-hover:visible text-gray-400'
+                                          : 'text-black'}`}
                                       >
                                         {collapsedObjectives.has(objective.key) ? (
                                           <ChevronRightIcon className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- keep area and objective chevrons hidden until hover
- show chevrons in black when expanded

## Testing
- `npm test --silent`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a34b08be0832a983b26e2529958c2